### PR TITLE
Allow unicode characters in encoded data

### DIFF
--- a/form-urlencoded.js
+++ b/form-urlencoded.js
@@ -10,7 +10,10 @@ var formurlencoded = module.exports = function (data, opts) {
 
   function encode (value) {
     return String(value)
-      .replace(/[^ !'()~\*]/g, encodeURIComponent)
+      // The following is an ES5 compatible version of .replace(/[^ !'()~\*]/gu, encodeURIComponent)
+      // Thanks to https://mothereff.in/regexpu
+      .replace(/(?:[\0-\x1F"-&\+-\}\x7F-\uD7FF\uE000-\uFFFF]|[\uD800-\uDBFF][\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF])/g, encodeURIComponent)
+
       .replace(/ /g, '+')
       .replace(/[!'()~\*]/g, function (ch) {
         return '%' + ch.charCodeAt().toString(16).slice(-2).toUpperCase();

--- a/test/form-urlencoded.spec.js
+++ b/test/form-urlencoded.spec.js
@@ -155,4 +155,14 @@ describe("formurlencoded.encode", function () {
     ).toBe( 'parent%5Bfoo%5D=bar&parent%5BemptyArr%5D%5B%5D' );
   });
 
+  it("should return encoded urls with unicode characters", function() {
+    expect(
+      formurlencoded({
+        parent: {
+          foo: '😀',
+        }
+      })
+    ).toBe( 'parent%5Bfoo%5D=%F0%9F%98%80' );
+  });
+
 });


### PR DESCRIPTION
Hi, and thanks for this library!

I was just playing around with some user submitted data that we are form-urlencoding and came across the following error when using unicode characters (an 😀 emoji to be specific):

```
form-urlencoded.js:13 Uncaught URIError: URI malformed
```

ES6 adds the `/u` flag to Regular Expressions, [though browser / node support is not all that great](http://kangax.github.io/compat-table/es6/#test-RegExp_y_and_u_flags).

Fortunately @mathiasbynens has a great article about [Unicode-aware regular expressions in ECMAScript 6](https://mathiasbynens.be/notes/es6-unicode-regex), which links to his [regexpu](https://github.com/mathiasbynens/regexpu) project that rewrites ES6 Unicode regular expressions into equivalent ES5.

I used this to convert the `/[^ !'()~\*]/gu` regex to one that should work everywhere.

Tested in Node `v5.11.1` and `v6.2.0`.

Let me know if you have any questions, comments, or if there is anything I can do to help this along!

Thanks in advance!