### PR TITLE
Exporting default to match ES6 standard and definatly types definition

### DIFF
--- a/form-urlencoded.js
+++ b/form-urlencoded.js
@@ -2,7 +2,7 @@
 // Timestamp: 2017.07.04-19:19:11 (last modified)
 // Author(s): Bumblehead (www.bumblehead.com), JBlashill (james@blashill.com), Jumper423 (jump.e.r@yandex.ru)
 
-module.exports = (data, opts = {}) => {
+module.exports.default = (data, opts = {}) => {
     const sorted = Boolean(opts.sorted),
         skipIndex = Boolean(opts.skipIndex),
         ignorenull = Boolean(opts.ignorenull),


### PR DESCRIPTION
Currently the module @types/form-urlencoded states that the encoding function is exported as a default, this is the equivalent to using module.exports = ...

https://stackoverflow.com/questions/41666130/export-default-vs-module-exports-differences

This is causing issues in typescript projects, as using require leaves an implicit any type on the import.

Hence follow ES6 standard of exporting default.