### PR TITLE
Added missing ESM types subpath export condition.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "types": "form-urlencoded.d.ts",
   "exports": {
     ".": {
+      "types": "./form-urlencoded.d.ts",
       "require": "./form-urlencoded.js",
       "import": "./form-urlencoded.mjs"
-    },
-    "./": "./"
+    }
   },
   "version": "6.0.7",
   "description": "Return an object as an 'x-www-form-urlencoded' string",

--- a/package.json
+++ b/package.json
@@ -5,11 +5,9 @@
   "module": "form-urlencoded.mjs",
   "types": "form-urlencoded.d.ts",
   "exports": {
-    ".": {
-      "types": "./form-urlencoded.d.ts",
-      "require": "./form-urlencoded.js",
-      "import": "./form-urlencoded.mjs"
-    }
+    "types": "./form-urlencoded.d.ts",
+    "require": "./form-urlencoded.js",
+    "import": "./form-urlencoded.mjs"
   },
   "version": "6.0.7",
   "description": "Return an object as an 'x-www-form-urlencoded' string",


### PR DESCRIPTION
The TypeScript 4.7 `NodeNext` module resolver does not honor the legacy `types` property in the `package.json` file.  You need to add a `types` export condition as described [here](https://devblogs.microsoft.com/typescript/announcing-typescript-4-7/#package-json-exports-imports-and-self-referencing).

> Note that the "types" condition should always come first in "exports".

existing `package.json`
```jsonc
{
  "exports": {
    ".": {  // Don't need if only exporting from `./`
      // need `types` here
      "require": "./form-urlencoded.js",
      "import": "./form-urlencoded.mjs"
    },
     "./": "./"   // this is a typo and should be removed
  },
```

The simplified subpath `exports` can be simplified to:

```
  "exports": {
    "types": "./form-urlencoded.d.ts",
    "require": "./form-urlencoded.js",
    "import": "./form-urlencoded.mjs"
  }
```
